### PR TITLE
fix: move compinit after plugins to fix zsh completions

### DIFF
--- a/conf.d/10-aliases.zsh
+++ b/conf.d/10-aliases.zsh
@@ -19,7 +19,7 @@ alias rmdir='rm -rf'
 alias hg='history | rg '
 
 # ZSH source shortcuts
-alias s-zsh="source ~/.zshrc"
+alias zs="exec zsh"
 alias source-zsh="source ~/.zshrc"
 
 # Modern CLI tool aliases (only if installed)

--- a/lib/antidote.zsh
+++ b/lib/antidote.zsh
@@ -11,9 +11,6 @@ fi
 
 zsh_debug_section "Brew setup"
 
-# Completion system init (MUST be before plugins that use compdef)
-autoload -Uz compinit && compinit
-
 # Clone antidote if not present (XDG-compliant location)
 ANTIDOTE_HOME="${XDG_DATA_HOME:-$HOME/.local/share}/antidote"
 [[ -d "${XDG_DATA_HOME:-$HOME/.local/share}" ]] || mkdir -p "${XDG_DATA_HOME:-$HOME/.local/share}"
@@ -31,6 +28,9 @@ if [[ ! ${zsh_plugins}.zsh -nt ${zsh_plugins}.txt ]]; then
   antidote bundle < "${zsh_plugins}.txt" > "${zsh_plugins}.zsh"
 fi
 source "${zsh_plugins}.zsh"
+
+# Completion system init (AFTER plugins modify fpath)
+autoload -Uz compinit && compinit
 
 zsh_debug_section "Antidote plugins"
 


### PR DESCRIPTION
## Summary
- Fix zsh autocompletions by moving `compinit` after plugins load (was running before `zsh-completions` added to fpath)
- Add `zs` alias for `exec zsh` quick reload
- Remove redundant `s-zsh` alias

## Test plan
- [ ] Run `zs` to reload shell
- [ ] Test completions with `git <TAB>` or `docker <TAB>`