### PR TITLE
feat: add Stop hook to catch dismissive responses

### DIFF
--- a/config/claude/setup-settings.ts
+++ b/config/claude/setup-settings.ts
@@ -43,6 +43,16 @@ settings.hooks = {
       ],
     },
   ],
+  Stop: [
+    {
+      hooks: [
+        {
+          type: "command",
+          command: `bun run ${configSrc}/stop-guard.ts`,
+        },
+      ],
+    },
+  ],
 };
 
 // --- Auto-update for all marketplaces ---

--- a/config/claude/stop-guard.ts
+++ b/config/claude/stop-guard.ts
@@ -1,0 +1,33 @@
+#!/usr/bin/env bun
+
+// Stop hook: catches when Claude dismisses issues as "not related to our changes"
+// and blocks the response, instructing it to address ALL issues found.
+
+export {};
+
+const input = await Bun.stdin.json();
+const message: string = input.last_assistant_message ?? "";
+
+const dismissivePatterns = [
+  /not (related|relevant) to (our|the|these|my) (changes|work|modifications)/i,
+  /pre-existing (issue|bug|error|problem)/i,
+  /outside (the |our |of )?scope/i,
+  /unrelated to (our|the|my) (work|changes|task)/i,
+  /not (caused|introduced) by (our|the|this|my)/i,
+  /existed before (our|the|this|my)/i,
+  /not something we (need to|should) (fix|address)/i,
+  /beyond (the |our )?scope/i,
+  /separate (issue|concern|problem|PR|ticket)/i,
+];
+
+const match = dismissivePatterns.find((p) => p.test(message));
+
+if (match) {
+  console.log(
+    JSON.stringify({
+      decision: "block",
+      reason:
+        "You dismissed an issue as not related to our changes. Address ALL errors and issues found during your work, regardless of their source. Do not defer issues to separate PRs or tickets unless explicitly asked.",
+    })
+  );
+}


### PR DESCRIPTION
Adds a Claude Code Stop hook that detects when Claude dismisses errors or issues as "not related to our changes" and blocks the response. Forces Claude to address all issues found during work rather than deferring them.

- `config/claude/stop-guard.ts` — pattern-matching hook that catches dismissive phrases and returns a block decision with corrective instructions
- `config/claude/setup-settings.ts` — registers the Stop hook in the settings harness

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Claude_Code-Opus_4.6_(1M)-D97757?logo=claude&logoColor=white)