### PR TITLE
feat(claude,zsh): tt-update, terminal-reply guards, conditional --chrome

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -145,11 +145,67 @@ zsh_debug_section "word-navigation"
 # If a TUI (Claude Code, nvim, etc.) enables enhanced keys and crashes without
 # popping the mode, Ghostty sends sequences like ESC[1;29A for arrow keys and
 # zle leaks "29A" as literal text. Clearing flags on every prompt is defensive.
-_reset_keyboard_protocol() { printf '\e[=0u' }
+# Pop the kitty stack before clearing — ESC[=0u only zeroes the top entry, so
+# stale pushes underneath would resurface later. Also drop color-scheme
+# reporting (2031); TUIs re-enable it when they start.
+_reset_keyboard_protocol() {
+  printf '\e[<3u\e[=0u\e[?2031l'
+  # Inside tmux that only reaches the pane pty. A dead TUI can leave the kitty
+  # protocol stuck on the OUTER terminal too (Esc arrives as CSI 27u → dead Esc,
+  # phantom shortcuts). When this prompt is in the focused pane of an attached
+  # session, heal the Ghostty-facing client tty directly.
+  if [[ -n $TMUX && -n $TMUX_PANE ]]; then
+    # One call: the pane the client is currently viewing, and the client tty.
+    # Only the viewed pane's prompt may touch the outer terminal (sessions can
+    # share linked windows, so resolving via session names is unreliable).
+    local cur ctty
+    read -r cur ctty <<< "$(tmux display-message -p '#{pane_id} #{client_tty}' 2>/dev/null)"
+    [[ $cur == "$TMUX_PANE" && -w $ctty ]] && printf '\e[<3u\e[=0u' > "$ctty"
+  fi
+  return 0
+}
 autoload -Uz add-zsh-hook
 add-zsh-hook precmd _reset_keyboard_protocol
 
 zsh_debug_section "keyboard-protocol-reset"
+
+################################################
+#   Swallow stray terminal-query replies
+################################################
+# TUIs (Claude Code) probe terminal capabilities on startup: DECRQM for modes
+# 2026/2027/2031/1004/1016/2004, a kitty-graphics query (i=31337), and DA1.
+# If the app exits before reading Ghostty's replies, they land at the prompt as
+# garbage like "1016;2$y2027;1$y...Gi=31337;OK62;22;52c". These prefixes never
+# come from a keyboard, so bind them to widgets that drain the reply instead.
+
+# CSI replies (ESC [ ? ... ): DECRPM ends in $y, DA1 in c, kitty-kbd in u,
+# cursor position in R — all end at the first ASCII letter.
+_swallow_csi_reply() {
+  local c
+  while read -t 0.05 -k 1 c; do
+    [[ $c == [a-zA-Z] ]] && break
+  done
+}
+zle -N _swallow_csi_reply
+bindkey '\e[?' _swallow_csi_reply
+
+# String replies (APC kitty-graphics, DCS, OSC color queries): terminated by
+# ST (ESC \) or BEL. Compare char codes — a bare backslash misbehaves in
+# zsh pattern context ([[ $c == '\\' ]] fails to match it).
+_swallow_st_reply() {
+  local c prev=''
+  while read -t 0.05 -k 1 c; do
+    (( #prev == 27 && #c == 92 )) && break  # ESC \
+    (( #c == 7 )) && break                  # BEL
+    prev=$c
+  done
+}
+zle -N _swallow_st_reply
+bindkey '\e_' _swallow_st_reply   # APC (kitty graphics reply)
+bindkey '\eP' _swallow_st_reply   # DCS
+bindkey '\e]' _swallow_st_reply   # OSC (color/background query replies)
+
+zsh_debug_section "terminal-reply-guard"
 
 ################################################
 #   zsh-z (directory jumping)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,8 +82,8 @@ gca   → git add . && git-ai-commit
 ga    → git add .
 gp    → git push
 gs    → git status
-c     → claude --dangerously-skip-permissions --chrome
-cr    → claude --dangerously-skip-permissions --chrome --resume
+c     → claude --permission-mode auto (--chrome on Linux)
+cr    → claude --permission-mode auto --resume (--chrome on Linux)
 code  → code-insiders
 ls    → ls -al
 ez    → exec zsh

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "dotfiles",
       "dependencies": {
+        "@towles/tool": "^0.0.142",
         "picocolors": "^1.1.1",
       },
       "devDependencies": {
@@ -13,14 +14,64 @@
     },
   },
   "packages": {
+    "@anthropic-ai/claude-code": ["@anthropic-ai/claude-code@2.1.170", "", { "optionalDependencies": { "@anthropic-ai/claude-code-darwin-arm64": "2.1.170", "@anthropic-ai/claude-code-darwin-x64": "2.1.170", "@anthropic-ai/claude-code-linux-arm64": "2.1.170", "@anthropic-ai/claude-code-linux-arm64-musl": "2.1.170", "@anthropic-ai/claude-code-linux-x64": "2.1.170", "@anthropic-ai/claude-code-linux-x64-musl": "2.1.170", "@anthropic-ai/claude-code-win32-arm64": "2.1.170", "@anthropic-ai/claude-code-win32-x64": "2.1.170" }, "bin": { "claude": "bin/claude.exe" } }, "sha512-/kMpp+fz72boi8KvAW4EZ1G8FWtPAR3vH1uKGlYpoZ2O9SU5XdaYCTvw5tPyYGDoB+eFiOnolfTiKPUK8vnP7g=="],
+
+    "@anthropic-ai/claude-code-darwin-arm64": ["@anthropic-ai/claude-code-darwin-arm64@2.1.170", "", { "os": "darwin", "cpu": "arm64" }, "sha512-lnBfVVTO+Wk31IAh5KDOY+Cuu1vIHC3N3UjHY9SEroDat8XKqjFtckY50jPi50m5x0oWkeQiyDl4nPstgdkNwQ=="],
+
+    "@anthropic-ai/claude-code-darwin-x64": ["@anthropic-ai/claude-code-darwin-x64@2.1.170", "", { "os": "darwin", "cpu": "x64" }, "sha512-w2lZwSsKDVqrY8O6N65SSP309JJleWrUx9tltW2SIGaPRLybtrZf7q6KxDz3I/gEMBhpwnC2MHXYMU0sw6JXzg=="],
+
+    "@anthropic-ai/claude-code-linux-arm64": ["@anthropic-ai/claude-code-linux-arm64@2.1.170", "", { "os": "linux", "cpu": "arm64" }, "sha512-J2682NcqJbDouDcmR8VeVDAB4UxWryDMUZfPYdvbwiG3sM6SyupBHPuXgwIEcaT1M1jlpBiWRdJ4ActHF5Drng=="],
+
+    "@anthropic-ai/claude-code-linux-arm64-musl": ["@anthropic-ai/claude-code-linux-arm64-musl@2.1.170", "", { "os": "linux", "cpu": "arm64" }, "sha512-ClnCeAnKuOqyuEqU4jiEZSsdQfA8gzuEoiTCQtGEEYHWSwu341aZa35EmNl90JIXqIl5i8sNbA+ZMD+GEKGfUQ=="],
+
+    "@anthropic-ai/claude-code-linux-x64": ["@anthropic-ai/claude-code-linux-x64@2.1.170", "", { "os": "linux", "cpu": "x64" }, "sha512-SSQ6TsGbZJSC1s6R5pxlTZPq1bilSpoTR8JANOq8ALUkbRVhgVSl0PiSSNSnc3zNdDCA1iA3ywLmAuISuhlvKA=="],
+
+    "@anthropic-ai/claude-code-linux-x64-musl": ["@anthropic-ai/claude-code-linux-x64-musl@2.1.170", "", { "os": "linux", "cpu": "x64" }, "sha512-mPwe4thBIj8nAbhzkKGmCLnqWuFxUI1wvrFai7TttlPMMeM2gelXaJnfgo9LEgEkp5KqqBFZRNeYQREiJsEqUQ=="],
+
+    "@anthropic-ai/claude-code-win32-arm64": ["@anthropic-ai/claude-code-win32-arm64@2.1.170", "", { "os": "win32", "cpu": "arm64" }, "sha512-c3coVcbv6Ea8UBM4EYPbW341AC691Z9bCMEIWn/7YogLzRbBrhBQiMfPXN0qnapUMF8Osii093239PmdgXAHrA=="],
+
+    "@anthropic-ai/claude-code-win32-x64": ["@anthropic-ai/claude-code-win32-x64@2.1.170", "", { "os": "win32", "cpu": "x64" }, "sha512-wUcLJQuxirInc9mOqIY/z9i7eXxJFy7ShXtN+PZJpZRJJR8Evbx2ZbBwT/zcUNN1nyhHao34gwLp6LXHd3G9lg=="],
+
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.88.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-QQOtB5U9ZBJQj6y1ICmDZl14LWa4JCiJRoihI+0yuZ4OjbONrakP0yLwPv4DJFb3VYCtQM31bTOpCBMs2zghPw=="],
+
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.61.1", "", { "os": "linux", "cpu": "x64" }, "sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q=="],
+
+    "@towles/tool": ["@towles/tool@0.0.142", "", { "dependencies": { "@anthropic-ai/claude-code": "^2.1.107", "@anthropic-ai/sdk": "^0.88.0", "citty": "^0.2.2", "consola": "^3.4.2", "d3-hierarchy": "^3.1.2", "fzf": "^0.5.2", "luxon": "^3.7.2", "neverthrow": "^8.2.0", "picocolors": "^1.1.1", "prompts": "^2.4.2", "zod": "^4.3.6" }, "bin": { "towles-tool": "bin/run.ts", "tt": "bin/run.ts" } }, "sha512-sGfoYVmSUJPlUtMAI/nywIUtWQsLO2Bjd6Zf7qbeX/eNz56fyLvcPNH7p8wHtTj4mW6jmg66dFhSq8pwoLOyyw=="],
+
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 
     "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
 
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
+    "citty": ["citty@0.2.2", "", {}, "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w=="],
+
+    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
+
+    "d3-hierarchy": ["d3-hierarchy@3.1.2", "", {}, "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="],
+
+    "fzf": ["fzf@0.5.2", "", {}, "sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
+
+    "kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
+
+    "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
+
+    "neverthrow": ["neverthrow@8.2.0", "", { "optionalDependencies": { "@rollup/rollup-linux-x64-gnu": "^4.24.0" } }, "sha512-kOCT/1MCPAxY5iUV3wytNFUMUolzuwd/VF/1KCx7kf6CutrOsTie+84zTGTpgQycjvfLdBBdvBvFLqFD2c0wkQ=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
+    "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
+
+    "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
+
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
   }
 }

--- a/functions/15-bun.sh
+++ b/functions/15-bun.sh
@@ -8,6 +8,17 @@ case ":$PATH:" in
   *) export PATH="$BUN_INSTALL/bin:$PATH" ;;
 esac
 
+# tt-update - Install latest @towles/tool globally and restart agentboard
+tt-update() {
+  echo "tt $(tt --version 2>/dev/null || echo 'not installed')"
+  bun install --global @towles/tool@latest || { echo "install failed" >&2; return 1; }
+  echo "tt $(tt --version)"
+  if pgrep -f "agentboard server" >/dev/null 2>&1; then
+    echo "restarting agentboard..."
+    tt agentboard restart
+  fi
+}
+
 # Install bun in setup mode
 if [[ "$DOTFILES_SETUP" -eq 1 ]]; then
   if command -v bun >/dev/null 2>&1; then
@@ -22,7 +33,9 @@ if [[ "$DOTFILES_SETUP" -eq 1 ]]; then
 
   # Install @towles/tool globally
   echo " Installing @towles/tool..."
-  bun install --global @towles/tool
+  if ! bun install --global @towles/tool; then
+    echo " ⚠️  @towles/tool install FAILED — tt not updated (still $(tt --version 2>/dev/null || echo 'not installed'))" >&2
+  fi
 
   # Generate zsh completions
   if command -v bun >/dev/null 2>&1; then

--- a/functions/60-claude-code.sh
+++ b/functions/60-claude-code.sh
@@ -79,10 +79,26 @@ fi
 export CLAUDE_CODE_NO_FLICKER=1
 export CLAUDE_CODE_NEW_INIT=1
 
-alias c="claude --dangerously-skip-permissions --chrome"
-alias cr="claude --dangerously-skip-permissions --chrome --resume"
-alias ca="claude --dangerously-skip-permissions --chrome agents"
-alias cc="claude --dangerously-skip-permissions --chrome --channels plugin:discord@claude-plugins-official"
-alias ccr="claude --dangerously-skip-permissions --chrome --channels plugin:discord@claude-plugins-official --resume"
+# Claude Code leaves theme-change reporting (DECSET 2031) enabled on exit; the
+# terminal then answers theme queries with `ESC[?997;1n` reports that echo into
+# the shell as junk. Disable the mode and drain queued reports after each run.
+_claude_run() {
+  claude "$@"
+  local rc=$?
+  printf '\e[?2031l'
+  while read -rs -t 0.05 -k 1; do :; done
+  return $rc
+}
+
+# --chrome only on Linux; on macOS it's not wanted.
+_claude_flags=(--permission-mode auto)
+[[ "$(uname -s)" == "Linux" ]] && _claude_flags+=(--chrome)
+_claude_discord=("${_claude_flags[@]}" --channels plugin:discord@claude-plugins-official)
+
+c()   { _claude_run "${_claude_flags[@]}" "$@" }
+cr()  { _claude_run "${_claude_flags[@]}" --resume "$@" }
+ca()  { _claude_run "${_claude_flags[@]}" agents "$@" }
+cc()  { _claude_run "${_claude_discord[@]}" "$@" }
+ccr() { _claude_run "${_claude_discord[@]}" --resume "$@" }
 
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "packageManager": "pnpm@10.28.0",
   "dependencies": {
+    "@towles/tool": "^0.0.142",
     "picocolors": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Claude aliases (`c/cr/ca/cc/ccr`) become `_claude_run`-wrapped functions; common flags live in arrays, and `--chrome` is appended only on Linux (dropped on macOS).
- Swallow stray terminal query replies: new `_swallow_csi_reply`/`_swallow_st_reply` zle widgets, and `_reset_keyboard_protocol` now pops the kitty stack + clears mode 2031 (with a tmux client-tty heal).
- `_claude_run` disables DECSET 2031 and drains queued reports after each run.
- Add `tt-update` to refresh the global `@towles/tool` install and restart agentboard.
- Switch `c/cr` from `--dangerously-skip-permissions` to `--permission-mode auto`.

## Test
- `zsh -n` parses `functions/60-claude-code.sh`.
- On macOS the resolved flags are `--permission-mode auto` (no `--chrome`); the `uname -s == Linux` check appends `--chrome`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)