### PR TITLE
fix(fzf): detect broken fd shims during setup, not just missing fd

### DIFF
--- a/functions/20-fzf.sh
+++ b/functions/20-fzf.sh
@@ -5,9 +5,15 @@
 # Ctrl+T: paste files/dirs, Ctrl+R: history, Alt+C: cd into dir
 if [[ "$DOTFILES_SETUP" -eq 1 ]] ; then
   # Install fd (faster find, used by fzf)
-  if ! command -v fd >/dev/null 2>&1; then
+  # Probe with `fd --version`, not `command -v` — a broken npm fd-find shim
+  # (postinstall never fetched the binary) once shadowed fd and passed the
+  # existence check while failing every actual invocation
+  if ! fd --version >/dev/null 2>&1; then
     echo " Installing fd..."
     cargo install fd-find
+    if [[ "$(command -v fd)" != "$HOME/.cargo/bin/fd" ]]; then
+      DOTFILES_SETUP_MESSAGES+=("⚠️  fd on PATH is $(command -v fd), not ~/.cargo/bin/fd — a broken shim may be shadowing it")
+    fi
   fi
 
   if ! command -v fzf >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
Yesterday's `lsf` failure traced back to a pnpm-global npm `fd-find` package: its postinstall never downloaded the real binary, so the shim printed `fd failed to install, please install it again` on every call — but it still satisfied `command -v fd`, so `zsh-dotfiles-setup` never installed the real cargo fd. This silently broke everything fd-backed: `lsf`, `fh`, fzf Ctrl+T and Alt+C.

- Setup now probes with `fd --version` (catches both missing *and* broken-but-present fd)
- After installing, if the `fd` that wins on PATH still isn't `~/.cargo/bin/fd`, a post-setup warning names the shadowing path

The broken shim on this machine was already removed manually (`pnpm remove -g fd-find`) and cargo fd 10.4.2 installed; this PR is the guard so it can't happen silently again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)