### PR TITLE
docs(readme): update alias table for claude/eza changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,13 @@ git config --global user.email "you@example.com"
 | `gp` | `git push` |
 | `gs` | `git status` |
 | `gw` | `gh browse` |
-| `c` | `claude --dangerously-skip-permissions` |
-| `cr` | `claude --dangerously-skip-permissions --resume` |
+| `c` / `cr` | `claude --permission-mode auto --model sonnet --effort high` (`--chrome` on Linux); `cr` resumes |
+| `cf` / `cfr` | same, Fable model at medium effort ("fast draft"); `cfr` resumes |
+| `cfa` / `cfar` | same, Fable model at xhigh effort ("architect"); `cfar` resumes |
 | `code` | `code-insiders` |
-| `ls` | `ls -al` |
+| `ls` | `eza -la` (dirs first, git status, icons; falls back to `ls -al`) |
+| `lt` | `eza --tree` (tree view, `lt [depth]`) |
+| `lsf` | fuzzy-filter files under cwd and open the pick in `$EDITOR` |
 | `ez` | `exec zsh` |
 | `dif` | `delta` (syntax-highlighted diff) |
 


### PR DESCRIPTION
## Summary
- Update the README alias table to reflect the `c`/`cf`/`cfa` (and `-r` resume variants) Claude Code launcher aliases with their model/effort settings
- Update the `ls` row and add `lt`/`lsf` rows for the eza-based aliases

## Test plan
- Docs-only change, no runtime behavior affected