### PR TITLE
feat(claude): add Handy install, fix towles-tool marketplace mismatch

### DIFF
--- a/config/claude/setup-settings.ts
+++ b/config/claude/setup-settings.ts
@@ -69,7 +69,7 @@ const marketplaces: [string, string][] = [
   ["anthropics/claude-plugins-official", "claude-plugins-official"],
   ["anthropics/skills", "anthropic-agent-skills"],
   ["anthropics/knowledge-work-plugins", "knowledge-work-plugins"],
-  ["ChrisTowles/towles-tool", "towles-tool"],
+  ["ChrisTowles/towles-tool-rs", "towles-tool"],
 ];
 
 
@@ -82,7 +82,7 @@ const installs: Install[] = [
   { kind: "github_marketplace", name: "frontend-design",      marketplace: "claude-plugins-official" },
   { kind: "github_marketplace", name: "plugin-dev",           marketplace: "claude-plugins-official" },
   { kind: "github_marketplace", name: "skill-creator",        marketplace: "claude-plugins-official" },
-  { kind: "github_marketplace", name: "tt",                   marketplace: "towles-tool-rs" },
+  { kind: "github_marketplace", name: "tt",                   marketplace: "towles-tool" },
   { kind: "github_marketplace", name: "document-skills",      marketplace: "anthropic-agent-skills" },
   { kind: "github_marketplace", name: "humanizer",            marketplace: "humanizer" },
   { kind: "github_marketplace", name: "code-simplifier",      marketplace: "claude-plugins-official" },
@@ -100,18 +100,13 @@ const uninstalls: Uninstall[] = [
 ];
 
 // Marketplaces to remove. Move entries here from `marketplaces` to uninstall on next setup.
-const uninstallMarketplaces: string[] = [];
+// Also use this for a same-name repo swap (e.g. towles-tool -> towles-tool-rs): the
+// `existsSync` check below only keys on the registered name, so if a name already
+// points at an old repo it will never be refreshed to the new source unless removed
+// first. Removal runs before the add loop so the swap completes in a single run.
+const uninstallMarketplaces: string[] = ["towles-tool"];
 
 const marketplacesDir = join(process.env.HOME!, ".claude", "plugins", "marketplaces");
-
-for (const [repo, name] of marketplaces) {
-  if (existsSync(join(marketplacesDir, name))) {
-    console.log(` Claude marketplace already added: ${name}`);
-  } else {
-    console.log(` Adding Claude marketplace: ${repo}`);
-    Bun.spawnSync(["claude", "plugin", "marketplace", "add", repo], { stdio: ["ignore", "inherit", "inherit"] });
-  }
-}
 
 for (const name of uninstallMarketplaces) {
   const result = Bun.spawnSync(["claude", "plugin", "marketplace", "remove", name], { stdout: "pipe", stderr: "pipe" });
@@ -119,6 +114,15 @@ for (const name of uninstallMarketplaces) {
     console.log(` Removed Claude marketplace: ${name}`);
   } else {
     console.log(` Claude marketplace already removed: ${name}`);
+  }
+}
+
+for (const [repo, name] of marketplaces) {
+  if (existsSync(join(marketplacesDir, name))) {
+    console.log(` Claude marketplace already added: ${name}`);
+  } else {
+    console.log(` Adding Claude marketplace: ${repo}`);
+    Bun.spawnSync(["claude", "plugin", "marketplace", "add", repo], { stdio: ["ignore", "inherit", "inherit"] });
   }
 }
 

--- a/functions/82-handy.sh
+++ b/functions/82-handy.sh
@@ -1,0 +1,30 @@
+# Handy — free, open source, offline speech-to-text app (Tauri v2)
+# https://github.com/cjpais/Handy
+
+if [[ "$DOTFILES_SETUP" -eq 1 ]]; then
+  case "$(uname -s)" in
+    Darwin)
+      if [[ ! -d "/Applications/Handy.app" ]]; then
+        echo " Installing Handy..."
+        brew install --cask handy
+      fi
+      ;;
+    Linux)
+      if ! command -v handy >/dev/null 2>&1; then
+        echo " Installing Handy..."
+        gh release download --repo cjpais/Handy --pattern "*_amd64.deb" -D /tmp --clobber
+        sudo apt install -y /tmp/Handy_*_amd64.deb
+        rm -f /tmp/Handy_*_amd64.deb
+      fi
+
+      # wtype: Wayland text-input backend (Handy falls back to unreliable enigo without it).
+      # libgtk-layer-shell0: runtime dep Handy links against on Linux.
+      for pkg in wtype libgtk-layer-shell0; do
+        if ! dpkg -s "$pkg" &>/dev/null; then
+          echo " Installing $pkg..."
+          sudo apt install -y "$pkg"
+        fi
+      done
+      ;;
+  esac
+fi


### PR DESCRIPTION
## Summary
- Add `functions/82-handy.sh` to install Handy (offline speech-to-text) — Homebrew cask on macOS, `gh release` `.deb` on Linux — plus `wtype`/`libgtk-layer-shell0` for Wayland text input.
- Fix `config/claude/setup-settings.ts`: the `towles-tool-rs` repo's `marketplace.json` registers itself as `"towles-tool"`, not `"towles-tool-rs"`, so the `tt` plugin install was failing against a marketplace name that was never added. Point the marketplace entry at the new repo and correct the `tt` plugin's marketplace name, with a one-cycle removal to swap the stale registration.

## Test plan
- [ ] `zsh -n functions/82-handy.sh`
- [ ] `bunx tsc --noEmit`
- [ ] Run `zsh-dotfiles-setup` and confirm `tt@towles-tool` installs successfully