### PR TITLE
feat(herdr): add herdr terminal workspace manager setup

### DIFF
--- a/functions/63-herdr.sh
+++ b/functions/63-herdr.sh
@@ -1,0 +1,23 @@
+# herdr - terminal workspace manager for AI coding agents
+# https://herdr.dev
+
+if [[ "$DOTFILES_SETUP" -eq 1 ]]; then
+  if command -v herdr >/dev/null 2>&1; then
+    case "$(uname -s)" in
+      Darwin) echo " Updating herdr (brew)..."; brew upgrade herdr 2>/dev/null || true ;;
+      Linux)  echo " Updating herdr..."; herdr update 2>/dev/null || true ;;
+    esac
+  else
+    echo " Installing herdr..."
+    case "$(uname -s)" in
+      Darwin) brew install herdr ;;
+      Linux)  curl -fsSL https://herdr.dev/install.sh | sh ;;
+    esac
+  fi
+
+  # Generate zsh completions
+  if command -v herdr >/dev/null 2>&1; then
+    echo " Generating herdr completions..."
+    herdr completion zsh > ~/.zsh/completions/_herdr
+  fi
+fi


### PR DESCRIPTION
## Summary
- Adds `functions/63-herdr.sh` to install/update [herdr](https://herdr.dev) (brew on macOS, official install script on Linux) and generate zsh completions.

## Test plan
- [x] `zsh -n functions/63-herdr.sh`
- [x] `bun run lint`
- [x] Ran module locally with `DOTFILES_SETUP=1`, confirmed herdr installs/updates and completions generate

🤖 Generated with [Claude Code](https://claude.com/claude-code)