### PR TITLE
feat(claude): add plannotator CLI install and plugin marketplace

### DIFF
--- a/config/claude/setup-settings.ts
+++ b/config/claude/setup-settings.ts
@@ -70,6 +70,7 @@ const marketplaces: [string, string][] = [
   ["anthropics/skills", "anthropic-agent-skills"],
   ["anthropics/knowledge-work-plugins", "knowledge-work-plugins"],
   ["ChrisTowles/towles-tool-rs", "towles-tool"],
+  ["backnotprop/plannotator", "plannotator"],
 ];
 
 
@@ -87,6 +88,7 @@ const installs: Install[] = [
   { kind: "github_marketplace", name: "humanizer",            marketplace: "humanizer" },
   { kind: "github_marketplace", name: "code-simplifier",      marketplace: "claude-plugins-official" },
   { kind: "github_marketplace", name: "data",                 marketplace: "knowledge-work-plugins" },
+  { kind: "github_marketplace", name: "plannotator",          marketplace: "plannotator" },
 ];
 
 // Move entries here from `installs` to remove them on next setup.

--- a/functions/83-plannotator.sh
+++ b/functions/83-plannotator.sh
@@ -1,0 +1,9 @@
+# Plannotator - Claude Code planning/annotation tool
+# https://plannotator.ai
+
+if [[ "$DOTFILES_SETUP" -eq 1 ]]; then
+  if ! command -v plannotator >/dev/null 2>&1; then
+    echo " Installing plannotator..."
+    curl -fsSL https://plannotator.ai/install.sh | bash
+  fi
+fi


### PR DESCRIPTION
## Summary
- Install the `plannotator` CLI via its curl install script (`functions/83-plannotator.sh`), following the existing `herdr` pattern
- Register the `backnotprop/plannotator` marketplace and add the `plannotator` plugin install entry in `config/claude/setup-settings.ts`

## Test plan
- [x] `bunx tsc --noEmit` passes
- [x] `zsh -n functions/83-plannotator.sh` passes
- [ ] Run `DOTFILES_SETUP=1 exec zsh` on a machine to confirm the CLI and plugin install end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)