### PR TITLE
fix(zsh): enable INTERACTIVE_COMMENTS

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -263,6 +263,13 @@ zstyle ':completion:*' group-name ''
 
 
 ###############################
+# Shell Options
+###############################
+# Off by default in interactive zsh — without it, pasting a command with a
+# trailing `# comment` errors out instead of ignoring the comment.
+setopt INTERACTIVE_COMMENTS
+
+###############################
 # History Configuration
 ###############################
 HISTFILE=~/.zsh_history


### PR DESCRIPTION
`INTERACTIVE_COMMENTS` is off by default in interactive zsh, so pasting a command with a trailing `# comment` errored instead of ignoring the comment. Enabled it in a new "Shell Options" section in `.zshrc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)