### PR TITLE
feat(ghostty): copy selected text to the system clipboard

### DIFF
--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -1,0 +1,5 @@
+# Ghostty config
+# https://ghostty.org/docs/config
+
+# Copy selected text straight to the system clipboard (no Ctrl+Shift+C needed).
+copy-on-select = clipboard

--- a/functions/81-ghostty.sh
+++ b/functions/81-ghostty.sh
@@ -15,6 +15,19 @@ if [[ "$DOTFILES_SETUP" -eq 1 ]]; then
         ;;
     esac
   fi
+
+  local config_src="${0:a:h}/../config/ghostty/config"
+  if [[ -f "$config_src" ]]; then
+    echo " Linking Ghostty config..."
+    local config_dir
+    if [[ "$(uname)" == "Darwin" ]]; then
+      config_dir="$HOME/Library/Application Support/com.mitchellh.ghostty"
+    else
+      config_dir="$HOME/.config/ghostty"
+    fi
+    mkdir -p "$config_dir"
+    ln -sf "$config_src" "$config_dir/config"
+  fi
 fi
 
 # ghostty-help - Print Ghostty tips and workarounds
@@ -26,6 +39,9 @@ ghostty-help() {
   echo "  Cmd+Shift+D        Split down"
   echo "  Cmd+Shift+Enter    Toggle fullscreen"
   echo "  Cmd+Shift+,        Open config"
+  echo ""
+  echo "\033[1;36mConfig:\033[0m"
+  echo "  copy-on-select = clipboard  (selecting text copies it automatically)"
   echo ""
   echo "\033[1;36mKnown issues:\033[0m"
   echo "  Right-click menu in tmux is broken (follows cursor)"


### PR DESCRIPTION
Adds a default Ghostty config that copies selected/highlighted text to the system clipboard automatically.

- `config/ghostty/config` — sets `copy-on-select = clipboard`. Ghostty’s default is `true`, which on Linux only fills the primary selection (middle-click), so selected text was not available to Ctrl+V.
- `functions/81-ghostty.sh` — setup symlinks the config to `~/.config/ghostty/config` (macOS: `~/Library/Application Support/com.mitchellh.ghostty/config`), matching the lazygit pattern. `ghostty-help` mentions the behavior.

Verified with `ghostty +show-config` after linking: reports `copy-on-select = clipboard`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)