### PR TITLE
fix(gh): define _pr_stacked_base inside pr() so it survives Claude Code shell snapshots

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,6 +148,6 @@ The work profile (`212787373_aero`) is the global default — this repo override
   sudo install /tmp/tool /usr/local/bin/tool
   ```
 - Rust ecosystem tools (bat, fd, eza, delta, starship) install via `cargo install`
-- Private/internal shell functions use underscore prefix (e.g. `_nerd_fonts_install`)
+- Private/internal shell functions use underscore prefix (e.g. `_nerd_fonts_install`). Caveat: Claude Code's shell snapshot (which seeds its Bash tool sessions with your interactive functions) drops all underscore-prefixed functions — so a public function that calls a `_helper` at runtime will hit "command not found" inside Claude sessions. If a helper must exist wherever its public caller does, define it nested inside the caller (see `pr()` in `functions/35-gh.sh`); top-level underscore helpers are fine for setup-gated code and completions
 - Claude Code MCP servers are registered via `claude mcp add -s user` (stored in `~/.claude.json`), NOT in `settings.json`. The `settings.json` `mcpServers` field should stay empty. Setup in `60-claude-code.sh` handles idempotent registration.
 - Chrome DevTools MCP uses `--autoConnect` which connects to an existing Chrome session via the user data directory pipe. Requires Chrome 144+ with remote debugging enabled at `chrome://inspect/#remote-debugging`.

--- a/functions/35-gh.sh
+++ b/functions/35-gh.sh
@@ -41,33 +41,36 @@ gib() {
   gh issue list --state open | fzf --header "Select issue" | awk '{print $1}' | xargs -I{} gh issue develop {} --checkout
 }
 
-# Find the nearest local ancestor branch (excluding main/master) that already
-# has an open PR, so a stacked branch's PR targets it instead of main.
-_pr_stacked_base() {
-  local branch=$1 trunk=main candidate count
-  git show-ref --verify --quiet refs/heads/main || trunk=master
-
-  local -a pairs
-  while IFS= read -r candidate; do
-    [[ "$candidate" == "$branch" || "$candidate" == "$trunk" ]] && continue
-    git merge-base --is-ancestor "$candidate" "$branch" 2>/dev/null || continue
-    count=$(git rev-list --count "$candidate..$branch")
-    pairs+=("$count $candidate")
-  done < <(git for-each-ref --format='%(refname:short)' refs/heads)
-
-  # Nearest ancestor first (fewest commits between it and the current branch)
-  while IFS= read -r candidate; do
-    [[ -z "$candidate" ]] && continue
-    if gh pr view "$candidate" --json state --jq '.state' 2>/dev/null | grep -q '^OPEN$'; then
-      echo "$candidate"
-      return
-    fi
-  done < <(printf '%s\n' "${pairs[@]}" | sort -n | cut -d' ' -f2-)
-}
-
 # Push to origin and open GitHub PR creation, targeting a stacked branch's
 # open PR instead of main when the current branch was forked from one
 pr() {
+  # Find the nearest local ancestor branch (excluding main/master) that already
+  # has an open PR, so a stacked branch's PR targets it instead of main.
+  # Defined inside pr() on purpose: Claude Code shell snapshots drop
+  # top-level underscore-prefixed functions, so a nested definition is the
+  # only way the helper reliably exists wherever pr() does.
+  _pr_stacked_base() {
+    local branch=$1 trunk=main candidate count
+    git show-ref --verify --quiet refs/heads/main || trunk=master
+
+    local -a pairs
+    while IFS= read -r candidate; do
+      [[ "$candidate" == "$branch" || "$candidate" == "$trunk" ]] && continue
+      git merge-base --is-ancestor "$candidate" "$branch" 2>/dev/null || continue
+      count=$(git rev-list --count "$candidate..$branch")
+      pairs+=("$count $candidate")
+    done < <(git for-each-ref --format='%(refname:short)' refs/heads)
+
+    # Nearest ancestor first (fewest commits between it and the current branch)
+    while IFS= read -r candidate; do
+      [[ -z "$candidate" ]] && continue
+      if gh pr view "$candidate" --json state --jq '.state' 2>/dev/null | grep -q '^OPEN$'; then
+        echo "$candidate"
+        return
+      fi
+    done < <(printf '%s\n' "${pairs[@]}" | sort -n | cut -d' ' -f2-)
+  }
+
   local remote=origin
   local branch
   branch=$(git symbolic-ref --short HEAD)


### PR DESCRIPTION
## Problem

Running `pr` inside a Claude Code session printed `_pr_stacked_base: command not found`. The push and browser-open still worked, but stacked-PR base detection silently fell back to targeting `main`.

## Root cause

Claude Code seeds its Bash tool sessions from a snapshot of the interactive shell's functions (`~/.claude/shell-snapshots/`). That capture **drops every underscore-prefixed function** — the latest snapshot kept 81 public functions including `pr()`, but none of the repo's `_helper` functions. (The only two `__*` names present come from starship's init re-evaluating inside the snapshot, not from the capture — so a `__` rename wouldn't help.) So `pr` existed but its helper didn't.

## Fix

- Move `_pr_stacked_base()` inside `pr()` as a nested definition, so the helper's text travels with `pr`'s captured body and defines itself on every call. Verified by eval'ing only `typeset -f pr` output (what a snapshot contains) in a clean shell with stubbed `git`/`gh`: no "command not found", stacked detection targets the ancestor branch correctly.
- Document the snapshot caveat under CLAUDE.md conventions, since `_claude_run` (60-claude-code.sh) and `_cbk_ready` (68-restic.sh) follow the same pattern — left as-is because their callers are only used interactively, but future modules should know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)