### PR TITLE
feat(granted): install granted.dev for AWS SSO profile switching

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Each file in `functions/` is a self-contained module for one tool. Files follow 
 - **50-vscode.sh** - VS Code Insiders install, keybindings symlink
 - **55-starship.sh** - Prompt init with git metrics display
 - **60-claude-code.sh** - Claude Code install, statusline/notification hooks, MCP server setup via `claude mcp add`, zsh completions generated from `claude --help` (config/generate-completions.ts, shared with `tt` in 19-tt.sh)
+- **64-granted.sh** - granted.dev AWS SSO profile switcher; `assume`/`assumef` aliases (`assume` must be *sourced* to export AWS_* into the shell). Config file `~/.granted/config` is symlinked from `~/code/p/toolbox` via that repo's sync manifest, not from here
 - **65-aws-cli.sh** - AWS CLI completions (manual install warning)
 - **68-restic.sh** - Encrypted backups of `~/.claude/projects` via restic; `cbk`/`cbk-now`/`cbk-restore`, generates + enables the `restic-claude-sessions` systemd user timer. Requires `CLAUDE_BACKUP_REPO` to be set explicitly (no default — see docs/linux-setup-notes.md#restic)
 - **70-i.sh** - Quick `cd` to project directories under `~/code/{p,w,f}`

--- a/config/help.ts
+++ b/config/help.ts
@@ -98,6 +98,13 @@ console.log(cmd("cbk-now", "Back up ~/.claude/projects now"));
 console.log(cmd("cbk-restore [glob]", "Restore latest snapshot to a temp dir"));
 console.log();
 
+console.log(h("AWS") + dim("  (granted)"));
+console.log(cmd("assume [profile]", "Assume an AWS profile (fzf picker if no args)"));
+console.log(cmd("assumef", "Same, bypassing the credential cache"));
+console.log(cmd("assume -c", "Open the AWS console in the browser"));
+console.log(cmd("granted sso populate", "Generate ~/.aws/config profiles from SSO"));
+console.log();
+
 console.log(h("Other"));
 console.log(cmd("code", "VS Code Insiders"));
 console.log(cmd("bat", "Syntax-highlighted cat (cat stays plain)"));

--- a/functions/64-granted.sh
+++ b/functions/64-granted.sh
@@ -1,0 +1,33 @@
+# granted - AWS SSO profile switcher (https://granted.dev)
+
+if [[ "$DOTFILES_SETUP" -eq 1 ]]; then
+  if ! command -v granted >/dev/null 2>&1; then
+    echo " Installing granted..."
+    case "$(uname -s)" in
+      Darwin)
+        brew tap common-fate/granted
+        brew install granted
+        ;;
+      Linux)
+        rm -f /tmp/granted_*_linux_x86_64.tar.gz(N)
+        gh release download --repo common-fate/granted --pattern "granted_*_linux_x86_64.tar.gz" -D /tmp
+        tar xzf /tmp/granted_*_linux_x86_64.tar.gz -C /tmp assume assumego granted
+        sudo install /tmp/granted /tmp/assume /tmp/assumego /usr/local/bin/
+        rm -f /tmp/granted /tmp/assume /tmp/assumego /tmp/granted_*_linux_x86_64.tar.gz(N)
+        ;;
+    esac
+  fi
+
+  # granted writes its own completions under ~/.granted/zsh_autocomplete/<cmd>/_<cmd>
+  # rather than to stdout, so generate then copy into the shared completions dir
+  if command -v granted >/dev/null 2>&1; then
+    echo " Generating granted completions..."
+    granted completion -s zsh >/dev/null 2>&1
+    cp -f ~/.granted/zsh_autocomplete/granted/_granted ~/.zsh/completions/_granted 2>/dev/null
+    cp -f ~/.granted/zsh_autocomplete/assume/_assume ~/.zsh/completions/_assume 2>/dev/null
+  fi
+fi
+
+# `assume` must be sourced, not executed — it exports AWS_* into the current shell
+alias assume="source assume"
+alias assumef="assume --no-cache"

--- a/functions/65-aws-cli.sh
+++ b/functions/65-aws-cli.sh
@@ -46,4 +46,4 @@ fi
 
 # AWS aliases
 # alias awsp='aws --profile'
-alias assumef='assume --no-cache'
+# `assume` / `assumef` live in 64-granted.sh


### PR DESCRIPTION
Adds `functions/64-granted.sh` — installs [granted](https://granted.dev) (brew tap on macOS, `gh release download` of the x86_64 tarball into `/usr/local/bin` on Linux) and defines the `assume` / `assumef` aliases.

Two things worth a second look:

- `assume` is aliased to `source assume`, not run directly. The script exports `AWS_*` into the calling shell, so executing it in a subshell silently does nothing.
- `granted completion -s zsh` writes files to `~/.granted/zsh_autocomplete/<cmd>/_<cmd>` rather than stdout, so setup generates them there and copies both into `~/.zsh/completions/`.

`assumef` moved here from `65-aws-cli.sh`, where it had been sitting without the tool that provides it.

## Verification

Ran on Linux: granted 0.39.0 installed, `DOTFILES_SETUP=1` block put `_granted` and `_assume` in the fpath dir, both aliases resolve (`assume` → `source assume` → `/usr/local/bin/assume`). `bun run lint` passes.

## Not in this PR

`~/.granted/config` is symlinked in from `~/code/p/toolbox` via that repo's sync manifest — the default browser and keyring settings live there, not here. `CLAUDE.md` notes this so the next reader doesn't go looking for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)