### PR TITLE
feat(aws): add granted-populate to regenerate all local SSO profiles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Each file in `functions/` is a self-contained module for one tool. Files follow 
 - **50-vscode.sh** - VS Code Insiders install, keybindings symlink
 - **55-starship.sh** - Prompt init with git metrics display
 - **60-claude-code.sh** - Claude Code install, statusline/notification hooks, MCP server setup via `claude mcp add`, zsh completions generated from `claude --help` (config/generate-completions.ts, shared with `tt` in 19-tt.sh)
-- **65-aws-cli.sh** - AWS CLI completions (manual install warning)
+- **65-aws-cli.sh** - AWS CLI + SAM install and completions; granted.dev aliases — `assumef`, and `granted-populate` to regenerate every local profile from SSO (`granted sso populate --prune`, backs up `~/.aws/config` first)
 - **68-restic.sh** - Encrypted backups of `~/.claude/projects` via restic; `cbk`/`cbk-now`/`cbk-restore`, generates + enables the `restic-claude-sessions` systemd user timer. Requires `CLAUDE_BACKUP_REPO` to be set explicitly (no default — see docs/linux-setup-notes.md#restic)
 - **70-i.sh** - Quick `cd` to project directories under `~/code/{p,w,f}`
 - **75-docker.sh** - Docker Engine install with completions

--- a/config/help.ts
+++ b/config/help.ts
@@ -98,6 +98,11 @@ console.log(cmd("cbk-now", "Back up ~/.claude/projects now"));
 console.log(cmd("cbk-restore [glob]", "Restore latest snapshot to a temp dir"));
 console.log();
 
+console.log(h("AWS") + dim("  (granted.dev)"));
+console.log(cmd("assumef", "assume --no-cache (pick a profile)"));
+console.log(cmd("granted-populate", "Regenerate all local profiles from SSO (prunes stale)"));
+console.log();
+
 console.log(h("Other"));
 console.log(cmd("code", "VS Code Insiders"));
 console.log(cmd("bat", "Syntax-highlighted cat (cat stays plain)"));

--- a/functions/65-aws-cli.sh
+++ b/functions/65-aws-cli.sh
@@ -47,3 +47,46 @@ fi
 # AWS aliases
 # alias awsp='aws --profile'
 alias assumef='assume --no-cache'
+
+# Regenerate every local AWS profile from SSO (granted.dev).
+# Backs up ~/.aws/config, then repopulates it with every account/role the SSO
+# session grants, pruning generated profiles that no longer exist.
+#
+# Usage: granted-populate [sso-start-url]
+#   Start URL / region resolve in order: argument, $AWS_SSO_START_URL /
+#   $AWS_SSO_REGION (set these in ~/.zshrc_local.sh), then the first
+#   sso_start_url / sso_region already in ~/.aws/config.
+granted-populate() {
+  if ! command -v granted >/dev/null 2>&1; then
+    echo "granted not installed - see https://granted.dev" >&2
+    return 1
+  fi
+
+  local aws_config="${AWS_CONFIG_FILE:-$HOME/.aws/config}"
+  local start_url="${1:-$AWS_SSO_START_URL}"
+  local sso_region="$AWS_SSO_REGION"
+
+  if [ -z "$start_url" ] && [ -f "$aws_config" ]; then
+    start_url=$(awk -F'=' '/^[[:space:]]*sso_start_url[[:space:]]*=/ {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); print $2; exit}' "$aws_config")
+  fi
+  if [ -z "$sso_region" ] && [ -f "$aws_config" ]; then
+    sso_region=$(awk -F'=' '/^[[:space:]]*sso_region[[:space:]]*=/ {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); print $2; exit}' "$aws_config")
+  fi
+
+  if [ -z "$start_url" ]; then
+    echo "No SSO start URL found. Pass one as an argument or set AWS_SSO_START_URL in ~/.zshrc_local.sh" >&2
+    return 1
+  fi
+
+  if [ -f "$aws_config" ]; then
+    local backup="$aws_config.bak.$(date +%Y%m%d%H%M%S)"
+    cp "$aws_config" "$backup" || return 1
+    echo "Backed up $aws_config -> $backup"
+  fi
+
+  local -a region_arg
+  [ -n "$sso_region" ] && region_arg=(--sso-region "$sso_region")
+
+  echo "Populating profiles from $start_url${sso_region:+ ($sso_region)}..."
+  granted sso populate --prune "${region_arg[@]}" "$start_url"
+}


### PR DESCRIPTION
## Summary

Adds `granted-populate` to `functions/65-aws-cli.sh` — a wrapper around `granted sso populate --prune` that repopulates `~/.aws/config` with a profile for every account/role the SSO session grants, and removes generated profiles that no longer exist.

```bash
granted-populate                                    # discovers start URL from existing config
granted-populate https://myorg.awsapps.com/start    # or pass one explicitly
```

## Notes

- **Nothing org-specific is hardcoded.** The SSO start URL and region resolve in order: command argument → `$AWS_SSO_START_URL` / `$AWS_SSO_REGION` (set in `~/.zshrc_local.sh`) → the first `sso_start_url` / `sso_region` already in `~/.aws/config`.
- **Backs up `~/.aws/config`** to a timestamped `.bak` before running, since `--prune` deletes entries. Pruning only touches profiles granted itself generated (those carrying `common_fate_generated_from`), so hand-written profiles survive.
- Uses a zsh array for the optional `--sso-region` flag — `${var:+--flag "$var"}` does not word-split in zsh and would pass one mashed-together argument.
- Also adds an AWS section to `zsh-dotfiles-help` and updates the `65-aws-cli.sh` module description in `CLAUDE.md`.

## Testing

- `bun run lint` and `bunx tsc --noEmit` pass.
- Exercised both resolution paths against a stub `granted` on `PATH`, confirming the argv:
  ```
  FAKE granted called with: sso populate --prune --sso-region us-west-2 https://example.awsapps.com/start
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)