### PR TITLE
feat(bitwarden): install the Bitwarden CLI on Linux

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ Each file in `functions/` is a self-contained module for one tool. Files follow 
 - **64-granted.sh** - granted.dev AWS SSO profile switcher; `assume`/`assumef` aliases (`assume` must be *sourced* to export AWS_* into the shell), plus `granted-populate` to regenerate every local profile from SSO (`granted sso populate --prune`, backs up `~/.aws/config` first). Config file `~/.granted/config` is symlinked from `~/code/p/toolbox` via that repo's sync manifest, not from here
 - **65-aws-cli.sh** - AWS CLI completions (manual install warning)
 - **68-restic.sh** - Encrypted backups of `~/.claude/projects` via restic; `cbk`/`cbk-now`/`cbk-restore`, generates + enables the `restic-claude-sessions` systemd user timer. Requires `CLAUDE_BACKUP_REPO` to be set explicitly (no default — see docs/linux-setup-notes.md#restic)
+- **69-bitwarden.sh** - Bitwarden CLI (`bw`), **Linux only** (macOS: `brew install bitwarden-cli` by hand). Resolves the newest `cli-v*` tag in `bitwarden/clients` (that repo also ships browser/desktop/web releases, so `--latest` is unreliable), downloads `bw-linux-<version>.zip`, installs to `/usr/local/bin`, generates completions
 - **70-i.sh** - Quick `cd` to project directories under `~/code/{p,w,f}`
 - **75-docker.sh** - Docker Engine install with completions
 - **76-chrome.sh** - Google Chrome install via apt repo / brew cask

--- a/docs/linux-setup-notes.md
+++ b/docs/linux-setup-notes.md
@@ -12,6 +12,7 @@ Wayland
 - [Claude Code](https://claude.ai/code) - `npm install -g @anthropic-ai/claude-code`
 - [GitHub CLI](https://cli.github.com/) - `sudo apt install gh`
 - [restic](https://restic.net/) - encrypted, deduplicating backups - see [restic](#restic)
+- [Bitwarden CLI](https://bitwarden.com/help/cli/) - `bw` - installed from the latest `cli-v*` GitHub release by `functions/69-bitwarden.sh` (Linux only)
 
 ## Screenshot Shortcut
 

--- a/functions/69-bitwarden.sh
+++ b/functions/69-bitwarden.sh
@@ -1,0 +1,35 @@
+# bitwarden - password manager CLI (https://bitwarden.com/help/cli/)
+# Linux only. On macOS install it yourself with `brew install bitwarden-cli`.
+
+if [[ "$DOTFILES_SETUP" -eq 1 && "$(uname -s)" == "Linux" ]]; then
+  if ! command -v bw >/dev/null 2>&1; then
+    echo " Installing Bitwarden CLI..."
+    # bitwarden/clients ships browser/desktop/web releases from the same repo,
+    # so resolve the newest cli-v* tag rather than trusting "latest"
+    _bw_tag=$(gh release list --repo bitwarden/clients --limit 60 \
+      --json tagName --jq '[.[] | select(.tagName | startswith("cli-v"))][0].tagName')
+    if [[ -z "$_bw_tag" ]]; then
+      echo " Failed to resolve the latest Bitwarden CLI release"
+    else
+      # asset name is bw-linux-<version>.zip — match it exactly so the
+      # arm64 and -oss variants don't get pulled in too
+      _bw_zip="/tmp/bw-linux-${_bw_tag#cli-v}.zip"
+      rm -f "$_bw_zip" /tmp/bw
+      if gh release download "$_bw_tag" --repo bitwarden/clients \
+          --pattern "bw-linux-${_bw_tag#cli-v}.zip" -D /tmp \
+        && unzip -qo "$_bw_zip" bw -d /tmp; then
+        sudo install /tmp/bw /usr/local/bin/bw
+      else
+        echo " Failed to install Bitwarden CLI from $_bw_tag"
+      fi
+      rm -f "$_bw_zip" /tmp/bw
+    fi
+    unset _bw_tag _bw_zip
+  fi
+
+  # Generate zsh completions
+  if command -v bw >/dev/null 2>&1; then
+    echo " Generating Bitwarden CLI completions..."
+    bw completion --shell zsh > ~/.zsh/completions/_bw
+  fi
+fi


### PR DESCRIPTION
Adds `functions/69-bitwarden.sh`, gated to `DOTFILES_SETUP=1` on Linux.

## What it does

1. Resolves the newest `cli-v*` tag from `bitwarden/clients`. That repo publishes browser/desktop/web releases from the same tag stream, so the GitHub "latest" release isn't reliably the CLI — hence an explicit `gh release list` + `--jq` filter rather than the usual `--latest` shorthand.
2. Downloads `bw-linux-<version>.zip` by exact name. A `bw-linux-*.zip` glob would also match the `arm64` variant, and the repo ships `-oss` builds alongside — the exact name avoids both.
3. Unzips just the `bw` binary and `sudo install`s it to `/usr/local/bin/bw`, cleaning up `/tmp` on both success and failure.
4. Generates `~/.zsh/completions/_bw` via `bw completion --shell zsh`, matching the granted/herdr/tt pattern.

macOS is a no-op, so `brew install bitwarden-cli` stays a manual step (noted in the module header and CLAUDE.md).

No aliases or helper functions, so there's nothing to add to `config/help.ts`.

## Testing

Ran the resolve → download → unzip → `--version` → completion chain end to end against the live release (`cli-v2026.7.0`; extracted binary reports `2026.7.0`, completion output starts with a valid `#compdef _bw bw`). I stopped short of the `sudo install` step, so this hasn't been exercised as a full `zsh-dotfiles-setup` run yet — that's what @ChrisTowles is testing.

`bun run lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)