### PR TITLE
fix(karabiner): let towles-tool own its own Ctrl+Shift chords

### DIFF
--- a/config/karabiner/karabiner.json
+++ b/config/karabiner/karabiner.json
@@ -925,27 +925,6 @@
                             {
                                 "conditions": [
                                     {
-                                        "bundle_identifiers": ["^dev\\.towles\\.tool$"],
-                                        "type": "frontmost_application_if"
-                                    }
-                                ],
-                                "from": {
-                                    "key_code": "c",
-                                    "modifiers": {
-                                        "mandatory": ["control", "shift"]
-                                    }
-                                },
-                                "to": [
-                                    {
-                                        "key_code": "c",
-                                        "modifiers": ["left_command", "left_shift"]
-                                    }
-                                ],
-                                "type": "basic"
-                            },
-                            {
-                                "conditions": [
-                                    {
                                         "bundle_identifiers": [
                                             "^com\\.apple\\.Terminal$",
                                             "^com\\.googlecode\\.iterm2$",
@@ -984,8 +963,7 @@
                                             "^io\\.alacritty$",
                                             "^org\\.alacritty$",
                                             "^net\\.kovidgoyal\\.kitty$",
-                                            "^com\\.mitchellh\\.ghostty$",
-                                            "^dev\\.towles\\.tool$"
+                                            "^com\\.mitchellh\\.ghostty$"
                                         ],
                                         "type": "frontmost_application_if"
                                     }


### PR DESCRIPTION
towles-tool now takes Ctrl+Shift as a spelling of ⌘⇧ natively (ChrisTowles/towles-tool#601), so two manipulators in the Terminal Copy/Paste rule are no longer pulling their weight for `dev.towles.tool`:

- `Ctrl+Shift+C → ⌘⇧C` — dead weight; the app takes Ctrl+Shift+C as copy itself. Was app-only, so the manipulator goes entirely.
- `Ctrl+Shift+V → ⌃V` — actively harmful now: it rewrote the chord into readline's literal-next before the app could paste. App dropped from the list; every other terminal keeps it.

`Ctrl+V → ⌘V` stays for the app and every terminal — bare Ctrl+V still pastes, and that native-paste path is also how an image paste reaches the webview.

Ctrl+C is untouched. The PC-Style Copy/Paste/Cut rule still carves the app out, so ⌃C stays SIGINT in a terminal pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)