### PR TITLE
feat(cloudflare): add the cf CLI, plus plannotator removal and a granted fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ Each file in `functions/` is a self-contained module for one tool. Files follow 
 - **60-claude-code.sh** - Claude Code install, statusline/notification hooks, MCP server setup via `claude mcp add`, zsh completions generated from `claude --help` (config/generate-completions.ts, shared with `tt` in 19-tt.sh)
 - **64-granted.sh** - granted.dev AWS SSO profile switcher; `assume`/`assumef` aliases (`assume` must be *sourced* to export AWS_* into the shell), plus `granted-populate` to regenerate every local profile from SSO (`granted sso populate --prune`, backs up `~/.aws/config` first). Config file `~/.granted/config` is symlinked from `~/code/p/toolbox` via that repo's sync manifest, not from here
 - **65-aws-cli.sh** - AWS CLI completions (manual install warning)
+- **66-cloudflare.sh** - `cf`, the Cloudflare CLI (npm package `cf`, installed via `pnpm install --global`), plus zsh completions from `cf complete zsh`. Technical preview — positioned as the next version of Wrangler. Auth is interactive (`cf auth login`), not env vars. Note: *not* `flarectl` (the cloudflare-go CLI), which only shipped binaries on the abandoned `v0.*` tags
 - **68-restic.sh** - Encrypted backups of `~/.claude/projects` via restic; `cbk`/`cbk-now`/`cbk-restore`, generates + enables the `restic-claude-sessions` systemd user timer. Requires `CLAUDE_BACKUP_REPO` to be set explicitly (no default — see docs/linux-setup-notes.md#restic)
 - **69-bitwarden.sh** - Bitwarden CLI (`bw`), **Linux only** (macOS: `brew install bitwarden-cli` by hand). Resolves the newest `cli-v*` tag in `bitwarden/clients` (that repo also ships browser/desktop/web releases, so `--latest` is unreliable), downloads `bw-linux-<version>.zip`, installs to `/usr/local/bin`, generates completions
 - **70-i.sh** - Quick `cd` to project directories under `~/code/{p,w,f}`
@@ -89,8 +90,9 @@ gs    → git status
 c     → claude --permission-mode auto --model opus --effort high (--chrome on Linux)
 co/cor → same as c, explicit Opus name (cor resumes, overriding model/effort unlike cr)
 cs/csr → same, but --model sonnet --effort high (csr resumes, overriding model/effort)
-cf/cfa → same, but --model fable --effort medium/xhigh ("architect")
-cr/cfr/cfar → same as c/cf/cfa, plus --resume
+cfb/cfba → same, but --model fable --effort medium/xhigh ("architect")
+cr/cfbr/cfbar → same as c/cfb/cfba, plus --resume
+cf    → the Cloudflare CLI (NOT claude-fable — that's cfb)
 code  → code-insiders
 ls    → eza -la (dirs first, git status, icons; ls -al fallback)
 ez    → exec zsh

--- a/config/claude/setup-settings.ts
+++ b/config/claude/setup-settings.ts
@@ -72,7 +72,6 @@ const marketplaces: [string, string][] = [
   ["anthropics/skills", "anthropic-agent-skills"],
   ["anthropics/knowledge-work-plugins", "knowledge-work-plugins"],
   ["ChrisTowles/towles-tool-rs", "towles-tool"],
-  ["backnotprop/plannotator", "plannotator"],
 ];
 
 
@@ -91,7 +90,6 @@ const installs: Install[] = [
   { kind: "github_marketplace", name: "humanizer",            marketplace: "humanizer" },
   { kind: "github_marketplace", name: "code-simplifier",      marketplace: "claude-plugins-official" },
   { kind: "github_marketplace", name: "data",                 marketplace: "knowledge-work-plugins" },
-  { kind: "github_marketplace", name: "plannotator",          marketplace: "plannotator" },
   // Just the one skill, not the whole mattpocock/skills bundle (~40 skills, several
   // of which assume his ticket/spec workflow). Installs globally so it is always on.
   {
@@ -115,6 +113,7 @@ const uninstalls: Uninstall[] = [
   { kind: "github_marketplace", name: "hookify",                        marketplace: "claude-plugins-official" },
   { kind: "github_marketplace", name: "postman",                        marketplace: "claude-plugins-official" },
   { kind: "github_marketplace", name: "compound-engineering",           marketplace: "compound-engineering-plugin" },
+  { kind: "github_marketplace", name: "plannotator",                    marketplace: "plannotator" },
 ];
 
 // Marketplaces to remove. Move entries here from `marketplaces` to uninstall on next setup.
@@ -125,7 +124,7 @@ const uninstalls: Uninstall[] = [
 // Clear this after that run: removing a marketplace uninstalls every plugin it
 // owns, so leaving an entry here re-clones it and drops those plugins on each
 // setup — only the ones listed in `installs` come back.
-const uninstallMarketplaces: string[] = [];
+const uninstallMarketplaces: string[] = ["plannotator"];
 
 const marketplacesDir = join(process.env.HOME!, ".claude", "plugins", "marketplaces");
 

--- a/config/help.ts
+++ b/config/help.ts
@@ -86,9 +86,10 @@ console.log(h("Claude Code"));
 console.log(cmd("c", "claude --permission-mode auto --model opus --effort high"));
 console.log(cmd("co", "same as c, explicit Opus name"));
 console.log(cmd("cs", "claude ... --model sonnet --effort high"));
-console.log(cmd("cf", "claude ... --model fable --effort medium"));
-console.log(cmd("cfa", "claude ... --model fable --effort xhigh (\"architect\")"));
-console.log(cmd("cr / cor / csr / cfr / cfar", "same as c / co / cs / cf / cfa, plus --resume"));
+console.log(cmd("cfb", "claude ... --model fable --effort medium"));
+console.log(cmd("cfba", "claude ... --model fable --effort xhigh (\"architect\")"));
+console.log(cmd("cr", "--resume, keeping the session's own model/effort"));
+console.log(cmd("cor/csr/cfbr/cfbar", "--resume, overriding model/effort"));
 console.log(cmd("cprompts", "Browse skills/prompts baked into the claude binary (fzf)"));
 console.log();
 
@@ -103,6 +104,12 @@ console.log(cmd("assume [profile]", "Assume an AWS profile (fzf picker if no arg
 console.log(cmd("assumef", "Same, bypassing the credential cache"));
 console.log(cmd("assume -c", "Open the AWS console in the browser"));
 console.log(cmd("granted-populate", "Regenerate all ~/.aws/config profiles from SSO"));
+console.log();
+
+console.log(h("Cloudflare") + dim("  (cf; technical preview)"));
+console.log(cmd("cf", "The Cloudflare CLI (zones, dns, deploy, dev, ...)"));
+console.log(cmd("cf auth login", "Authenticate with Cloudflare"));
+console.log(cmd("cf auth whoami", "Show current user and auth status"));
 console.log();
 
 console.log(h("Other"));

--- a/functions/60-claude-code.sh
+++ b/functions/60-claude-code.sh
@@ -101,7 +101,8 @@ _claude_flags=(--permission-mode auto)
 
 # c/ca: Opus at high effort. cr: resume, no model/effort override (keeps the resumed session's own settings).
 # co/cor: Opus at high effort, explicit (cor overrides model/effort on resume, unlike cr).
-# cs/csr: Sonnet at high effort. cf/cfr: Fable at medium effort. cfa/cfar: Fable at xhigh ("architect").
+# cs/csr: Sonnet at high effort. cfb/cfbr: Fable at medium effort. cfba/cfbar: Fable at xhigh ("architect").
+# (Fable is cfb*, not cf* — `cf` is the Cloudflare CLI, see functions/66-cloudflare.sh.)
 _claude_flags_opus=("${_claude_flags[@]}" --model opus --effort high)
 _claude_flags_sonnet=("${_claude_flags[@]}" --model sonnet --effort high)
 _claude_flags_fable=("${_claude_flags[@]}" --model fable --effort medium)
@@ -117,17 +118,17 @@ cor()  { _claude_run "${_claude_flags_opus[@]}" --resume "$@"; }
 cs()   { _claude_run "${_claude_flags_sonnet[@]}" "$@"; }
 csr()  { _claude_run "${_claude_flags_sonnet[@]}" --resume "$@"; }
 
-cf()   { _claude_run "${_claude_flags_fable[@]}" "$@"; }
-cfr()  { _claude_run "${_claude_flags_fable[@]}" --resume "$@"; }
+cfb()  { _claude_run "${_claude_flags_fable[@]}" "$@"; }
+cfbr() { _claude_run "${_claude_flags_fable[@]}" --resume "$@"; }
 
-cfa()  { _claude_run "${_claude_flags_fable_architect[@]}" "$@"; }
-cfar() { _claude_run "${_claude_flags_fable_architect[@]}" --resume "$@"; }
+cfba()  { _claude_run "${_claude_flags_fable_architect[@]}" "$@"; }
+cfbar() { _claude_run "${_claude_flags_fable_architect[@]}" --resume "$@"; }
 
 # Complete the wrapper functions like `claude` itself. The _claude file is
 # generated during setup; compinit (which .zshrc runs before functions/) makes
 # it autoloadable, so only register when it exists.
 if [[ -f "$HOME/.zsh/completions/_claude" ]]; then
-  compdef _claude c cr ca co cor cs csr cf cfr cfa cfar
+  compdef _claude c cr ca co cor cs csr cfb cfbr cfba cfbar
 fi
 
 

--- a/functions/64-granted.sh
+++ b/functions/64-granted.sh
@@ -39,7 +39,10 @@ alias assumef="assume --no-cache"
 # Usage: granted-populate [sso-start-url]
 #   Start URL / region resolve in order: argument, $AWS_SSO_START_URL /
 #   $AWS_SSO_REGION (set these in ~/.zshrc_local.sh), then the first
-#   sso_start_url / sso_region already in ~/.aws/config.
+#   sso_start_url / sso_region already in ~/.aws/config. Profiles that granted
+#   generated spell those keys `granted_sso_*` — auth runs through
+#   credential_process, so a bare sso_start_url would make the CLI try SSO
+#   itself — hence the optional prefix in both patterns.
 granted-populate() {
   if ! command -v granted >/dev/null 2>&1; then
     echo "granted not installed - run: DOTFILES_SETUP=1 exec zsh" >&2
@@ -51,10 +54,10 @@ granted-populate() {
   local sso_region="$AWS_SSO_REGION"
 
   if [ -z "$start_url" ] && [ -f "$aws_config" ]; then
-    start_url=$(awk -F'=' '/^[[:space:]]*sso_start_url[[:space:]]*=/ {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); print $2; exit}' "$aws_config")
+    start_url=$(awk -F'=' '/^[[:space:]]*(granted_)?sso_start_url[[:space:]]*=/ {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); print $2; exit}' "$aws_config")
   fi
   if [ -z "$sso_region" ] && [ -f "$aws_config" ]; then
-    sso_region=$(awk -F'=' '/^[[:space:]]*sso_region[[:space:]]*=/ {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); print $2; exit}' "$aws_config")
+    sso_region=$(awk -F'=' '/^[[:space:]]*(granted_)?sso_region[[:space:]]*=/ {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); print $2; exit}' "$aws_config")
   fi
 
   if [ -z "$start_url" ]; then

--- a/functions/66-cloudflare.sh
+++ b/functions/66-cloudflare.sh
@@ -1,0 +1,25 @@
+# cf - the Cloudflare CLI (https://blog.cloudflare.com/cf-cli-local-explorer/)
+# Technical preview; positioned as the next version of Wrangler and eventually
+# covering the whole Cloudflare API surface. Ships as the npm package `cf`.
+#
+# NOT flarectl — that's the CLI in cloudflare-go, which only ever shipped
+# binaries on the abandoned v0.x tags and is no longer the tool to use.
+#
+# Auth is interactive: `cf auth login` (OAuth), `cf auth whoami` to check.
+# Named profiles via `cf auth create <name>` + `--profile`.
+
+if [[ "$DOTFILES_SETUP" -eq 1 ]]; then
+  if command -v pnpm >/dev/null 2>&1; then
+    echo " Installing Cloudflare CLI (cf)..."
+    pnpm install --global cf
+  else
+    echo " Skipping Cloudflare CLI — pnpm not found"
+  fi
+
+  # Generate zsh completions (emits a #compdef file despite the docs
+  # suggesting you append it straight to ~/.zshrc)
+  if command -v cf >/dev/null 2>&1; then
+    echo " Generating Cloudflare CLI completions..."
+    cf complete zsh > ~/.zsh/completions/_cf
+  fi
+fi


### PR DESCRIPTION
## Cloudflare `cf` CLI

Adds `functions/66-cloudflare.sh` for [`cf`](https://blog.cloudflare.com/cf-cli-local-explorer/), Cloudflare's new unified CLI — npm package `cf`, positioned as the next version of Wrangler and eventually covering the whole API surface. Installed via `pnpm install --global` to match the other node CLIs, with zsh completions from `cf complete zsh`.

**Not flarectl.** That CLI lives in `cloudflare-go` and only ever shipped binaries on the abandoned `v0.*` tags — the current `v7.x` releases are the generated Go SDK and carry no release assets at all. It's the wrong tool to reach for.

It's a technical preview (v0.5.0), so no convenience aliases on top of a command surface that's still churning. Auth is interactive (`cf auth login`), not env vars.

### Claude alias rename

The new binary is named `cf`, which collided with the claude-fable wrapper. Fable moves to `cfb` / `cfba` (`cfbr` / `cfbar` to resume), updated in the function definitions, the `compdef _claude` registration, `help.ts`, and `CLAUDE.md`.

While in `help.ts` I fixed a pre-existing formatting bug: the resume line's label was already 27 chars against a 20-char pad and ran into its own description. Splitting it also let me capture that `cr` keeps the resumed session's model/effort while `cor`/`csr`/`cfbr`/`cfbar` override it.

## plannotator removal

Moves the Claude plugin from `installs` to `uninstalls` and the `backnotprop/plannotator` registration to `uninstallMarketplaces`.

⚠️ Per the note above `uninstallMarketplaces`, that entry is transient — clear it back to `[]` after the setup run that performs the removal, or each subsequent run re-clones the marketplace and drops its plugins again.

This only covers the Claude plugin; `functions/83-plannotator.sh` still installs the standalone CLI.

## granted fix

`granted-populate`'s fallback scan of `~/.aws/config` only matched a bare `sso_start_url`, but profiles granted generates spell the keys `granted_sso_*` (auth runs through `credential_process`, so an unprefixed key would make the AWS CLI try SSO itself). On an already-populated config it found nothing and bailed asking for a start URL that was sitting right there. Makes the prefix optional in both awk patterns.

## Testing

- `bun run lint` and `bunx tsc --noEmit` pass
- Ran the new module for real: `cf v0.5.0` installed, `~/.zsh/completions/_cf` generated (7.7KB, correct `#compdef cf` header — upstream docs tell you to append it to `~/.zshrc`, but it's a proper compdef file)
- Verified `cf` resolves to the Cloudflare binary and all four `cfb*` functions resolve in a fresh interactive shell
- The flarectl binary from the first (wrong) pass was removed from `/usr/local/bin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)